### PR TITLE
Options for HTTP(S) protocol removing

### DIFF
--- a/lib/htmlcompressor/compressor.rb
+++ b/lib/htmlcompressor/compressor.rb
@@ -648,7 +648,13 @@ module HtmlCompressor
     def remove_http_protocol(html)
       # remove http protocol from tag attributes
       if @options[:remove_http_protocol]
-        html = html.gsub(HTTP_PROTOCOL_PATTERN) do |match|
+        pattern = case @options[:remove_http_protocol]
+          when true
+            HTTP_PROTOCOL_PATTERN
+          else
+            Regexp.new("(<[^>]+?(?:#{@options[:remove_http_protocol].gsub(",", "|")})\\s*=\\s*['\"])http:(//[^>]+?>)", Regexp::MULTILINE | Regexp::IGNORECASE)
+          end
+        html = html.gsub(pattern) do |match|
           group_1 = $1
           group_2 = $2
 
@@ -666,7 +672,14 @@ module HtmlCompressor
     def remove_https_protocol(html)
       # remove https protocol from tag attributes
       if @options[:remove_https_protocol]
-        html = html.gsub(HTTPS_PROTOCOL_PATTERN) do |match|
+        pattern = case @options[:remove_https_protocol]
+          when true
+            HTTPS_PROTOCOL_PATTERN
+          else
+            Regexp.new("(<[^>]+?(?:#{@options[:remove_https_protocol].gsub(",", "|")})\\s*=\\s*['\"])http:(//[^>]+?>)", Regexp::MULTILINE | Regexp::IGNORECASE)
+          end
+        
+        html = html.gsub(pattern) do |match|
           group_1 = $1
           group_2 = $2
 


### PR DESCRIPTION
Added functionality to specify which attributes are cleaned from HTTP(S) protocols.
I use lazyloading javascript library which uses special data-original attribute to store original image path. This needs also to be included in the list of attributes where protocol can be removed without problems.
Modified code that if @opions[:remove_http_protocol] is true, old functionality works as always.
If it is comma-separated list of attributes, those are used instead of predefined Regexp.

E.g.

``` ruby
@compressor = HtmlCompressor::Compressor.new({
    :remove_http_protocol => "href,src,cite,action,data-original,data-hires"
})
```
