### PR TITLE
use content.bytesize over content.length

### DIFF
--- a/lib/htmlcompressor/rack.rb
+++ b/lib/htmlcompressor/rack.rb
@@ -43,7 +43,7 @@ module HtmlCompressor
         end
 
         content = @compressor.compress(content)
-        headers['Content-Length'] = content.length.to_s if headers['Content-Length']
+        headers['Content-Length'] = content.bytesize.to_s if headers['Content-Length']
 
         [status, headers, [content]]
       else


### PR DESCRIPTION
on ruby 1.9.3, getting a wrong Content Length error from Rack::Lint. Looking into the gem, `content.length` should be replaced with `content.bytesize` to fix the error. 
