### PR TITLE
Change Content-Length header computation to be based on a number of bytes

### DIFF
--- a/lib/htmlcompressor/rack.rb
+++ b/lib/htmlcompressor/rack.rb
@@ -43,7 +43,7 @@ module HtmlCompressor
         end
 
         content = @compressor.compress(content)
-        headers['Content-Length'] = content.length.to_s if headers['Content-Length']
+        headers['Content-Length'] = content.bytesize.to_s if headers['Content-Length']
 
         [status, headers, [content]]
       else


### PR DESCRIPTION
... instead of a number of characters (which is not always the same, e.g. with accented characters)

The bug appeared when using Middleman (the gem middleman-minify-html uses htmlcompressor). See here : http://forum.middlemanapp.com/t/middleman-minify-html-content-length-header-error/697

Also, check this IRB session for a quick example:

2.0.0-p247 :001 > 'é'.length
 => 1 
2.0.0-p247 :002 > 'é'.bytesize
 => 2 
