### PR TITLE
Fix warning for duplicated keys

### DIFF
--- a/lib/htmlcompressor/compressor.rb
+++ b/lib/htmlcompressor/compressor.rb
@@ -128,9 +128,7 @@ module HtmlCompressor
       :preserve_line_breaks => false,
       :remove_surrounding_spaces => nil,
 
-      :preserve_patterns => nil,
-      :javascript_compressor => nil,
-      :css_compressor => nil
+      :preserve_patterns => nil
     }
 
     def initialize(options = {})


### PR DESCRIPTION
```bash
htmlcompressor-0.1.2/lib/htmlcompressor/compressor.rb:112: warning: duplicated key at line 132 ignored: :javascript_compressor
htmlcompressor-0.1.2/lib/htmlcompressor/compressor.rb:113: warning: duplicated key at line 133 ignored: :css_compressor
```