### PR TITLE
add support for custom javascript html template

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Please note that in order to use yui or closure compilers you need to manually a
   ...
 
   options = {
-    :compress_javscript => true,
+    :compress_javascript => true,
     :javascript_compressor => :yui,
     :compress_css => true
     :css_compressor => :yui

--- a/lib/htmlcompressor/compressor.rb
+++ b/lib/htmlcompressor/compressor.rb
@@ -317,6 +317,9 @@ module HtmlCompressor
           elsif type == 'text/x-jquery-tmpl'
             # jquery template, ignore so it gets compressed with the rest of html
             match
+          elsif !@options[:custom_js_html_template].nil? and @options[:custom_js_html_template].include?(type)
+            # ignore custom javascript html templates so it gets compressed with the rest of html
+            match            
           else
             # some custom script, preserve it inside "skip blocks" so it won't be compressed with js compressor
             skipBlocks << group_2

--- a/test/compressor_test.rb
+++ b/test/compressor_test.rb
@@ -86,6 +86,15 @@ module HtmlCompressor
 
       assert_equal result, compressor.compress(source)
     end
+        
+    def test_compress_custom_html_templates
+      source = read_resource("testCompressCustomHtmlTemplates.html")
+      result = read_resource("testCompressCustomHtmlTemplatesResult.html")
+
+      compressor = Compressor.new(:custom_js_html_template => ['text/html'])
+
+      assert_equal result, compressor.compress(source)
+    end
 
     def test_simple_doctype
       source = read_resource("testSimpleDoctype.html")
@@ -206,7 +215,6 @@ module HtmlCompressor
 
       assert_equal result, compressor.compress(source)
     end
-
   end
 
 end

--- a/test/resources/html/testCompressCustomHtmlTemplates.html
+++ b/test/resources/html/testCompressCustomHtmlTemplates.html
@@ -1,0 +1,1 @@
+<script type="text/html">     <a>     <!-- comment -->   <b>   </script>

--- a/test/resources/html/testCompressCustomHtmlTemplatesResult.html
+++ b/test/resources/html/testCompressCustomHtmlTemplatesResult.html
@@ -1,0 +1,1 @@
+<script type="text/html"> <a> <b> </script>


### PR DESCRIPTION
allow custom defined javascript html templates to be compressed. Similar to this request [https://code.google.com/p/htmlcompressor/issues/detail?id=78](https://code.google.com/p/htmlcompressor/issues/detail?id=78)