### PR TITLE
Reinstert skipped sections before building the rest of the html

### DIFF
--- a/lib/htmlcompressor/compressor.rb
+++ b/lib/htmlcompressor/compressor.rb
@@ -384,6 +384,16 @@ module HtmlCompressor
 
     def return_blocks(html, preBlocks, taBlocks, scriptBlocks, styleBlocks, eventBlocks, condCommentBlocks, skipBlocks, lineBreakBlocks, userBlocks)
 
+      # put skip blocks back
+      html = html.gsub(TEMP_SKIP_PATTERN) do |match|
+        i = $1.to_i
+        if skipBlocks.size > i
+          skipBlocks[i]
+        else
+          ''
+        end
+      end
+
       # put line breaks back
       if @options[:preserve_line_breaks]
         html = html.gsub(TEMP_LINE_BREAK_PATTERN) do |match|
@@ -454,15 +464,6 @@ module HtmlCompressor
         end
       end
 
-      # put skip blocks back
-      html = html.gsub(TEMP_SKIP_PATTERN) do |match|
-        i = $1.to_i
-        if skipBlocks.size > i
-          skipBlocks[i]
-        else
-          ''
-        end
-      end
 
       # put user blocks back
       unless @options[:preserve_patterns].nil?

--- a/test/compressor_test.rb
+++ b/test/compressor_test.rb
@@ -214,6 +214,13 @@ module HtmlCompressor
       assert_equal result, compressor.compress(source)
     end
 
+    def test_dont_replace_javascript_inside_js_templates
+      source = read_resource("testCompressCustomHtmlTemplates.html")
+      result = read_resource("testCompressCustomHtmlTemplates.html")
+      compressor = Compressor.new(:compress_js_templates => false, :remove_quotes => true)
+      assert_equal result, compressor.compress(source)
+    end
+
   end
 
 end

--- a/test/resources/html/testCompressCustomHtmlTemplates.html
+++ b/test/resources/html/testCompressCustomHtmlTemplates.html
@@ -1,1 +1,1 @@
-<script type="text/html">     <a attribute="value">     <!-- comment -->   <b>   </script>
+<script type="text/html">     <a attribute="value" onclick="alert('hello world')">     <!-- comment -->   <b>   </script>

--- a/test/resources/html/testCompressCustomHtmlTemplatesResult.html
+++ b/test/resources/html/testCompressCustomHtmlTemplatesResult.html
@@ -1,1 +1,1 @@
-<script type="text/html"> <a attribute="value"> <b> </script>
+<script type="text/html"> <a attribute="value" onclick="alert('hello world')"> <b> </script>


### PR DESCRIPTION
This fixes a bug were onclick events (and similar) would be output as their substitutions (ie, %%%~COMPRESS~EVENT~2~%%%) if they were inside a javascript template.

This is because the skipped sections were not added back into the html before the rest of the reinsertions. 
