### PR TITLE
Minifying JavaScript with yui is causing JS errors with <![CDATA[

### DIFF
--- a/lib/htmlcompressor/compressor.rb
+++ b/lib/htmlcompressor/compressor.rb
@@ -531,17 +531,11 @@ module HtmlCompressor
       end
 
       # detect CDATA wrapper
-      cdataWrapper = false
       if source =~ CDATA_PATTERN
-        cdataWrapper = true
         source = $1
       end
 
       result = javascript_compressor.compress(source).strip
-
-      if cdataWrapper
-        result = "<![CDATA[" + result + "]]>"
-      end
 
       result
     end

--- a/test/resources/html/testCompressJavaScriptClosureResult.html
+++ b/test/resources/html/testCompressJavaScriptClosureResult.html
@@ -1,4 +1,4 @@
-<script type="text/javascript">var a=0,a=a+1;alert(a);</script><script><![CDATA[var a=0,a=a+1;alert(a);]]></script><pre>
+<script type="text/javascript">var a=0,a=a+1;alert(a);</script><script>var a=0,a=a+1;alert(a);</script><pre>
 	<script>
 		var i = 0; //comment
 		i = i + 1;

--- a/test/resources/html/testCompressJavaScriptYuiResult.html
+++ b/test/resources/html/testCompressJavaScriptYuiResult.html
@@ -1,4 +1,4 @@
-<script type="text/javascript">var i=0;i=i+1;alert(i);</script><script><![CDATA[var i=0;i=i+1;alert(i);]]></script><pre>
+<script type="text/javascript">var i=0;i=i+1;alert(i);</script><script>var i=0;i=i+1;alert(i);</script><pre>
 	<script>
 		var i = 0; //comment
 		i = i + 1;


### PR DESCRIPTION
When we add JavaScript into rails, it automatically adds in the `//<![CDATA[` wrappers around the JavaScript. When we run the compressor with this:

```js
<script>
//<![CDATA[
  function() { ... }
//]]>
```

It outputs this:

```js
<script><![CDATA[function() { ... }]]>
```

which causes the function not to run. yui will removes the CDATA. 

This PR just removes the code that will re-add in a CDATA around the code. If we feel it is necessary to put it back in, I suggest adding a comment wrapper around them and making it optional. 