### PR TITLE
compressor presence check

### DIFF
--- a/lib/htmlcompressor/compressor.rb
+++ b/lib/htmlcompressor/compressor.rb
@@ -528,7 +528,11 @@ module HtmlCompressor
       end
 
       if javascript_compressor.nil?
-        raise MissingCompressorError, "No JavaScript Compressor. Please set the :javascript_compressor option"
+        if @options[:javascript_compressor].is_a?(Symbol)
+          raise NotFoundCompressorError, "JavaScript Compressor \"#{@options[:javascript_compressor]}\" not found, please check :javascript_compressor option"
+        else
+          raise MissingCompressorError, "No JavaScript Compressor. Please set the :javascript_compressor option"
+        end
       end
 
       # detect CDATA wrapper
@@ -556,7 +560,11 @@ module HtmlCompressor
       end
 
       if css_compressor.nil?
-        raise MissingCompressorError, "No CSS Compressor. Please set the :css_compressor option"
+        if @options[:css_compressor].is_a?(Symbol)
+          raise NotFoundCompressorError, "CSS Compressor \"#{@options[:css_compressor]}\" not found, please check :css_compressor option"
+        else
+          raise MissingCompressorError, "No CSS Compressor. Please set the :css_compressor option"
+        end
       end
 
       # detect CDATA wrapper

--- a/lib/htmlcompressor/exceptions.rb
+++ b/lib/htmlcompressor/exceptions.rb
@@ -1,3 +1,4 @@
 module HtmlCompressor
   class MissingCompressorError < StandardError; end
+  class NotFoundCompressorError < StandardError; end
 end

--- a/test/compressor_test.rb
+++ b/test/compressor_test.rb
@@ -224,6 +224,41 @@ module HtmlCompressor
       assert_equal result, compressor.compress(source)
     end
 
+    def test_javascript_compressor_not_found
+      source = read_resource("testCompressJavaScript.html");
+
+      compressor = Compressor.new(
+        :compress_javascript => true,
+        :javascript_compressor => :not_existing_compressor,
+        :remove_intertag_spaces => true,
+        :compress_js_templates => true
+      )
+
+      exception = assert_raises(NotFoundCompressorError) do
+        compressor.compress(source)
+      end
+
+      expect_message = 'JavaScript Compressor "not_existing_compressor" not found, please check :javascript_compressor option'
+      assert_equal(expect_message, exception.message)
+    end
+
+    def test_css_compressor_not_found
+      source = read_resource("testCompressCss.html");
+
+      compressor = Compressor.new(
+        :enabled => true,
+        :compress_css => true,
+        :css_compressor => :not_existing_compressor,
+        :compress_javascript => false
+      )
+
+      exception = assert_raises(NotFoundCompressorError) do
+        compressor.compress(source)
+      end
+
+      expect_message = 'CSS Compressor "not_existing_compressor" not found, please check :css_compressor option'
+      assert_equal(expect_message, exception.message)
+    end
   end
 
 end


### PR DESCRIPTION
I want to split exceptions: when compressor options not given and when it is not found.

So I added more friendly exception for case, when ` #get_javascript_compressor` or ` #get_css_compressor` not found compressor for given symbol.

Thank you for your job.